### PR TITLE
Jms verify spacing issue

### DIFF
--- a/src/XML.Tests/XML.Test.cs
+++ b/src/XML.Tests/XML.Test.cs
@@ -176,7 +176,6 @@ public class XMLTests
         string result = XML.Serialize(testObject, removeEmptyNodes: true);
 
         Assert.IsNotNull(result);
-        Console.WriteLine(result);
         StringAssert.Contains(result, "<Name>Test</Name>");
         Assert.IsFalse(result.Contains("xsi:nil=\"true\""));
     }
@@ -189,7 +188,6 @@ public class XMLTests
         string result = XML.Serialize(testObject, removeEmptyNodes: false);
 
         Assert.IsNotNull(result);
-        Console.WriteLine(result);
         StringAssert.Contains(result, "<Name>Test</Name>");
         Assert.IsTrue(result.Contains("xsi:nil=\"true\""));
     }
@@ -202,7 +200,6 @@ public class XMLTests
         string result = XML.Serialize(testObject, removeEmptyNodes: true);
 
         Assert.IsNotNull(result);
-        Console.WriteLine(result);
         Assert.IsFalse(result.Contains("xsi:nil=\"true\""));
     }
 

--- a/src/XML.Tests/XML.Test.cs
+++ b/src/XML.Tests/XML.Test.cs
@@ -176,6 +176,7 @@ public class XMLTests
         string result = XML.Serialize(testObject, removeEmptyNodes: true);
 
         Assert.IsNotNull(result);
+        Console.WriteLine(result);
         StringAssert.Contains(result, "<Name>Test</Name>");
         Assert.IsFalse(result.Contains("xsi:nil=\"true\""));
     }
@@ -188,6 +189,7 @@ public class XMLTests
         string result = XML.Serialize(testObject, removeEmptyNodes: false);
 
         Assert.IsNotNull(result);
+        Console.WriteLine(result);
         StringAssert.Contains(result, "<Name>Test</Name>");
         Assert.IsTrue(result.Contains("xsi:nil=\"true\""));
     }
@@ -200,6 +202,7 @@ public class XMLTests
         string result = XML.Serialize(testObject, removeEmptyNodes: true);
 
         Assert.IsNotNull(result);
+        Console.WriteLine(result);
         Assert.IsFalse(result.Contains("xsi:nil=\"true\""));
     }
 

--- a/src/XML/XML.csproj
+++ b/src/XML/XML.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>jmsudar.DotNet.Xml</PackageId>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Authors>JMSudar</Authors>
     <Description>.NET 6 native utilities for XML object manipulation</Description>
     <PackageTags>xml;serialization;deserialization</PackageTags>


### PR DESCRIPTION
# Overview

This finally resolves the issue with removing empty nodes.

Additionally, this adds a pretty print function, setting it to default, as that would hurt the updating of project files.

# Testing

Given how much trouble there was getting this to properly null check, I briefly printed the output to the console.

```
￼Success 'XML.src.XML.Tests.XMLTests.Serialize_WithRemoveEmptyNodes_RemovesEmptyElements'
Console output:
<?xml version="1.0" encoding="utf-8"?>
<TestObject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <Name>Test</Name>
</TestObject>

￼Success 'XML.src.XML.Tests.XMLTests.Serialize_WithoutRemoveEmptyNodes_KeepsEmptyElements'
Console output:
<?xml version="1.0" encoding="utf-8"?>
<TestObject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <Name>Test</Name>
  <Value xsi:nil="true" />
</TestObject>

￼Success 'XML.src.XML.Tests.XMLTests.Serialize_WithAllEmptyNodes_RemovesAllEmptyElements'
Console output:
<?xml version="1.0" encoding="utf-8"?>
<TestObject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"></TestObject>
```