### PR TITLE
Added new parameter for ommitting XML declarations

### DIFF
--- a/src/XML/XML.csproj
+++ b/src/XML/XML.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>jmsudar.DotNet.Xml</PackageId>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <Authors>JMSudar</Authors>
     <Description>.NET 6 native utilities for XML object manipulation</Description>
     <PackageTags>xml;serialization;deserialization</PackageTags>


### PR DESCRIPTION
# Overview

During testing with a live example, the update function was able to run, however it was not able to make the update successfully because the amended XML block had XML declarations, which breaks the validity for nuget.

#### Example: the second line breaks things
```xml
<Project Sdk="Microsoft.NET.Sdk">
  <?xml version="1.0" encoding="utf-8"?>
<PropertyGroup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
...
```

To help with this, a new boolean parameter in the `Serialize` method, `omitXmlDeclaration`. This parameter defaults to true and alters the XML writer settings so that the . If overridden and set to false, a block such as ` <?xml version="1.0" encoding="utf-8"?>` will be included at the top of what is serialized. This is useful if you are amending or creating an entirely new XML file, but otherwise should be left.

# Testing

Unit test coverage is sufficient.